### PR TITLE
Fix transfer error handling

### DIFF
--- a/abis/Client.json
+++ b/abis/Client.json
@@ -736,6 +736,11 @@
   },
   {
     "type": "error",
+    "name": "TransferFailed",
+    "inputs": []
+  },
+  {
+    "type": "error",
     "name": "UnfairDistribution",
     "inputs": [
       {

--- a/abis/Errors.json
+++ b/abis/Errors.json
@@ -72,6 +72,11 @@
   },
   {
     "type": "error",
+    "name": "TransferFailed",
+    "inputs": []
+  },
+  {
+    "type": "error",
     "name": "UnfairDistribution",
     "inputs": [
       {

--- a/src/Client.sol
+++ b/src/Client.sol
@@ -76,10 +76,11 @@ contract Client is Initializable, IClient, MulticallUpgradeable, Ownable2StepUpg
 
         allowances[msg.sender] -= datacapAmount;
         emit DatacapSpent(msg.sender, datacapAmount);
-        // slither-disable-start unused-return
         /// @custom:oz-upgrades-unsafe-allow-reachable delegatecall
-        DataCapAPI.transfer(params);
-        // slither-disable-end unused-return
+        (int256 exitCode,) = DataCapAPI.transfer(params);
+        if (exitCode != 0) {
+            revert Errors.TransferFailed();
+        }
     }
 
     /**

--- a/src/libs/Errors.sol
+++ b/src/libs/Errors.sol
@@ -61,4 +61,8 @@ library Errors {
     /// @dev Thrown if caller is invalid
     // 0x6a172882
     error InvalidCaller(address caller, address expectedCaller);
+
+    /// @dev Datacap transfer failed
+    // 0x90b8ec18
+    error TransferFailed();
 }


### PR DESCRIPTION
Surprisingly, `DataCapAPI.transfer(params)` doesn't revert if verifreg reverts.

Before:
```
kacper@kacper-HP-ProBook-445-G7 ~/f/boost (support-client-sol)> cast send [...] 'transfer(((bytes), (bytes, bool), bytes))' [...]

blockHash               0xb8e9b2d2c3ddddb625b1a48b8626dd1b76ceab487d2a6ea610c3d32e80f65282
blockNumber             21105
contractAddress         
cumulativeGasUsed       0
effectiveGasPrice       125081
from                    0x22fe179e35928D83E7a886c2d308c32425c019A0
gasUsed                 27962267
logs                    [{"address":"0x1D63202D817414F5a041Cf14Fa20cdAbe5d7e824","topics":["0xa61e0c49fdd997d62e953c4faf2651e76596f320d3dc2e1f9ba5636435341f61","0x00000000000000000000000022fe179e35928d83e7a886c2d308c32425c019a0"],"data":"0x0000000000000000000000000000000000000000000000000000000000800000","blockHash":"0xb8e9b2d2c3ddddb625b1a48b8626dd1b76ceab487d2a6ea610c3d32e80f65282","blockNumber":"0x5271","transactionHash":"0x2fad75b1d6dbe0a0496d3cb9328275ebbb16031fd1033544cd85f2f8b5517489","transactionIndex":"0x0","logIndex":"0x0","removed":false}]
logsBloom               0x00000000000008000000002000000000400080000000000000800000000020004000001102000000000000000840000000000801000000000000000004000000408000000000003000000000001002000001400000000000000400000000000000000000020804005000000000000800000100000001000000004000402008400000010000000000000820000100088000000000000080000000000000000000004000000000002000000000000000000000000004000080004000004000000000100020000000000000000000000000040000000004000000800004000020000000000000008000000000000000080000000000000008008800000000000000
root                    0x0000000000000000000000000000000000000000000000000000000000000000
status                  1 (success)
transactionHash         0x2fad75b1d6dbe0a0496d3cb9328275ebbb16031fd1033544cd85f2f8b5517489
transactionIndex        0
type                    2
blobGasPrice            
blobGasUsed             
authorizationList       
to                      0x1D63202D817414F5a041Cf14Fa20cdAbe5d7e824
```
Notice status success, but allocation wasn't made and state exec-trace says that verifreg had non-zero return code

After:
```
kacper@kacper-HP-ProBook-445-G7 ~/f/boost (support-client-sol)> cast send [...] 'transfer(((bytes), (bytes, bool), bytes))' [...]
Error: 
server returned an error response: error code 1: failed to estimate gas: message execution failed: exit 33, revert reason: 0x90b8ec18, vm error: message failed with backtrace:
00: f01013 (method 3844450837) -- contract reverted (33)
01: f01013 (method 6) -- contract reverted (33)
02: f07 (method 80475954) -- state transaction failed: error in underlying state negative balance caused by decreasing 1013's balance of TokenAmount(0.0) by TokenAmount(-8388608.0) (19)
 (RetCode=33)
```